### PR TITLE
fix standup list JSON Parsing error: missing value 'personalized'

### DIFF
--- a/geekbot_api/schemas.py
+++ b/geekbot_api/schemas.py
@@ -45,7 +45,7 @@ class StandupBase(BaseModel):
     channel: str
     questions: List[Question]
     users: List[User]
-    personalized: bool
+    personalized: Optional[bool]
 
 
 class Standup(StandupBase):


### PR DESCRIPTION
Simply made the personalized value Optional, then my test was working.

I also ran all the tests on my machine and they worked.